### PR TITLE
Update balanced-match to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "index.js"
   ],
   "dependencies": {
-    "balanced-match": "^0.1.0",
+    "balanced-match": "^0.2.0",
     "reduce-function-call": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
See https://github.com/juliangruber/balanced-match/compare/0.1.0...v0.2.0 for the list of differences.
The only noticable commit is https://github.com/juliangruber/balanced-match/commit/c67679cc5470deb8af372bada118af9e84eed7ad.
