### PR TITLE
Support uppercase letters in units

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function reduceCSSCalc(value, decimalPrecision) {
     }
 
     // Remove units in expression:
-    var toEvaluate = expression.replace(new RegExp(unit, "g"), "")
+    var toEvaluate = expression.replace(new RegExp(unit, "gi"), "")
     var result
 
     try {
@@ -134,7 +134,8 @@ function reduceCSSCalc(value, decimalPrecision) {
 
 function getUnitsInExpression(expression) {
   var uniqueUnits = []
-  var unitRegEx = /[\.0-9]([%a-z]+)/g
+  var uniqueLowerCaseUnits = []
+  var unitRegEx = /[\.0-9]([%a-z]+)/gi
   var matches = unitRegEx.exec(expression)
 
   while (matches) {
@@ -142,8 +143,9 @@ function getUnitsInExpression(expression) {
       continue
     }
 
-    if (uniqueUnits.indexOf(matches[1]) === -1) {
+    if (uniqueLowerCaseUnits.indexOf(matches[1].toLowerCase()) === -1) {
       uniqueUnits.push(matches[1])
+      uniqueLowerCaseUnits.push(matches[1].toLowerCase())
     }
 
     matches = unitRegEx.exec(expression)

--- a/test/index.js
+++ b/test/index.js
@@ -104,3 +104,12 @@ test("ignore unrecognized values", function(t) {
 
   t.end()
 })
+
+test("non-lowercase units", function(t) {
+  t.equal(reduceCSSCalc("calc(1PX)"), "1PX", "all uppercase");
+  t.equal(reduceCSSCalc("calc(1Px)"), "1Px", "first letter uppercase");
+  t.equal(reduceCSSCalc("calc(50% - 42Px)"), "calc(50% - 42Px)", "preserves percentage");
+  t.equal(reduceCSSCalc("calc(1Px + 1pX)"), "2Px", "combines same units mixed case");
+
+  t.end()
+})


### PR DESCRIPTION
This fixes issue #5: it makes the evaluator treats different case variants of a unit as equivalent, and output the leftmost one:

```
calc(1Px + 1px)  => 2Px
calc(1px + 1PX) => 2px
```
