### PR TITLE
Update balanced-match to ^0.4.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "index.js"
   ],
   "dependencies": {
-    "balanced-match": "^0.1.0",
+    "balanced-match": "^0.4.2",
     "math-expression-evaluator": "^1.2.9",
     "reduce-function-call": "^1.0.1"
   },


### PR DESCRIPTION
Closes #6.

Current tests pass so I don't see a reason why we're not on the latest version. 😄
