### PR TITLE
Don't process constant() and env(); fixes #34

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -338,3 +338,17 @@ test(
   'calc( (1em - calc( 10px + 1em)) / 2)',
   '-5px'
 )
+
+test(
+  'should skip constant()',
+  testFixture,
+  'calc(constant(safe-area-inset-left))',
+  'calc(constant(safe-area-inset-left))'
+)
+
+test(
+  'should skip env()',
+  testFixture,
+  'calc(env(safe-area-inset-left))',
+  'calc(env(safe-area-inset-left))'
+)

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,10 @@ export default (value, precision = 5) => {
 
     // stringify calc expression and produce an AST
     const contents = valueParser.stringify(node.nodes)
+
+    // skip constant() and env()
+    if (contents.indexOf('constant') >= 0 || contents.indexOf('env') >= 0) return;
+
     const ast = parser.parse(contents)
 
     // reduce AST to its simplest form, that is, either to a single value


### PR DESCRIPTION
Fix for #34 

Don't process `constant()` and `env()` since these are non-calc values.

Using solution provided by @guylando:
https://github.com/MoOx/reduce-css-calc/issues/34#issuecomment-416848813