### PR TITLE
jison: switch to maintained fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-config-i-am-meticulous": "^6.0.1",
     "eslint-plugin-babel": "^4.0.0",
     "eslint-plugin-import": "^2.2.0",
-    "jison": "https://github.com/download13/jison#b7d6e0de7d2c2c1bde5451b8e99813843a473315",
+    "jison-gho": "^0.6.1-216",
     "npmpub": "^4.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Hi @MoOx, thanks for this library!

I see that you're already using a custom fork of jison -- we are having issues downstream due to the `main()` function added to the end of `parser.js` by jison (for command-line usability -- it `require()`s the `fs` module, which doesn't exist in our build environment).

There are quite a few dangling PRs in the main jison repo, but this one is pretty active & maintained:
https://github.com/GerHobbelt/jison
available on npm: https://www.npmjs.com/package/jison-gho

I was considering creating my own fork, but I'd rather go with the community if possible.

Looks like the tests are all still passing -- hopefully this fork also addresses the use-cases that lead to you going off-package as well.
