### PR TITLE
Fix Parse error on custom property fallback

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -169,6 +169,35 @@ test(
 )
 
 test(
+  'should ignore calc with css variables (7)',
+  testFixture,
+  'calc(var(--popupHeight, var(--defaultHeight, var(--height-150))) / 2)',
+  'calc(var(--popupHeight, var(--defaultHeight, var(--height-150))) / 2)'
+)
+
+test(
+  'should ignore calc with css variables (8)',
+  testFixture,
+  'calc(var(--popupHeight, var(--defaultHeight, calc(100% - 50px))) / 2)',
+  'calc(var(--popupHeight, var(--defaultHeight, calc(100% - 50px))) / 2)'
+)
+
+test(
+  'should ignore calc with css variables (9)',
+  testFixture,
+  'calc(var(--popupHeight, var(--defaultHeight, calc(100% - 50px + 25px))) / 2)',
+  'calc(var(--popupHeight, var(--defaultHeight, calc(100% - 25px))) / 2)'
+)
+
+test(
+  'should ignore calc with css variables (10)',
+  testFixture,
+  'calc(var(--popupHeight, var(--defaultHeight, 150px)) / 2)',
+  'calc(var(--popupHeight, var(--defaultHeight, 150px)) / 2)'
+)
+
+
+test(
   'should reduce calc with newline characters',
   testFixture,
   'calc(\n1rem \n* 2 \n* 1.5)',

--- a/src/lib/reducer.js
+++ b/src/lib/reducer.js
@@ -3,6 +3,8 @@ import convert from './convert'
 function reduce(node, precision) {
   if (node.type === "MathExpression")
     return reduceMathExpression(node, precision)
+  if (node.type === "Calc")
+    return reduce(node.value, precision)
 
   return node
 }

--- a/src/lib/stringifier.js
+++ b/src/lib/stringifier.js
@@ -28,22 +28,30 @@ function stringify(node, prec) {
 
       str += " " + node.operator + " "
 
-      if (right.type === 'MathExpression' && order[op] < order[right.operator])
+      if (right.type === 'MathExpression' && order[op] < order[right.operator]) {
         str += "(" + stringify(right, prec) + ")"
-      else if (right.type === 'MathExpression' && op === "-" && ["+", "-"].includes(right.operator)) {
+      } else if (right.type === 'MathExpression' && op === "-" && ["+", "-"].includes(right.operator)) {
         // fix #52 : a-(b+c) = a-b-c
         right.operator = flip(right.operator);
         str += stringify(right, prec)
-      }
-      else
+      } else {
         str += stringify(right, prec)
+      }
 
       return str
     }
     case "Value":
       return round(node.value, prec)
     case 'CssVariable':
-      return node.value
+      if (node.fallback) {
+        return `var(${node.value}, ${stringify(node.fallback, prec, true)})`
+      }
+      return `var(${node.value})`
+    case 'Calc':
+      if (node.prefix) {
+        return `-${node.prefix}-calc(${stringify(node.value, prec)})`;
+      }
+      return `calc(${stringify(node.value, prec)})`;
     default:
       return round(node.value, prec) + node.unit
   }


### PR DESCRIPTION
Closes: https://github.com/MoOx/reduce-css-calc/issues/50

Hey, took a stab at fixing this issue. Essentially, recognize var declarations, and don't drop calcs because they can be nested with fallbacks
`calc(var(--popupHeight, var(--defaultHeight, calc(100% - 50px + 25px))) / 2)`