### PR TITLE
feat(): Fix Parse error on PX

### DIFF
--- a/parser.jison
+++ b/parser.jison
@@ -36,6 +36,7 @@
 ([0-9]+("."[0-9]*)?|"."[0-9]+)vmin\b   return 'VMINS';
 ([0-9]+("."[0-9]*)?|"."[0-9]+)vmax\b   return 'VMAXS';
 ([0-9]+("."[0-9]*)?|"."[0-9]+)\%       return 'PERCENTAGE';
+([0-9]+("."[0-9]*)?|"."[0-9]+)PX\b     return 'PX';
 ([0-9]+("."[0-9]*)?|"."[0-9]+)\b       return 'NUMBER';
 
 (calc)                                 return 'NESTED_CALC';
@@ -101,5 +102,6 @@ expression
   	| VMINS { $$ = { type: 'VminValue', value: parseFloat($1), unit: 'vmin' }; }
   	| VMAXS { $$ = { type: 'VmaxValue', value: parseFloat($1), unit: 'vmax' }; }
   	| PERCENTAGE { $$ = { type: 'PercentageValue', value: parseFloat($1), unit: '%' }; }
+  	| PX { $$ = { type: 'PXValue', value: parseFloat($1), unit: 'PX' }; }
   	| SUB css_value { var prev = $2; prev.value *= -1; $$ = prev; }
     ;

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -64,6 +64,13 @@ test(
 )
 
 test(
+  'should reduce simple calc (8)',
+  testFixture,
+  'calc(1PX + 1PX)',
+  '2PX'
+)
+
+test(
   'should reduce additions and subtractions (1)',
   testFixture,
   'calc(100% - 10px + 20px)',
@@ -75,6 +82,13 @@ test(
   testFixture,
   'calc(100% + 10px - 20px)',
   'calc(100% - 10px)'
+)
+
+test(
+  'should reduce additions and subtractions (3)',
+  testFixture,
+  'calc(100% + 10PX - 20PX)',
+  'calc(100% - 10PX)'
 )
 
 test(

--- a/src/lib/reducer.js
+++ b/src/lib/reducer.js
@@ -29,6 +29,7 @@ function isValueType(type) {
     case 'VminValue':
     case 'VmaxValue':
     case 'PercentageValue':
+    case 'PXValue':
     case 'Value':
       return true;
   }


### PR DESCRIPTION
#75 
PX unit support
`postcss-pxtorem` Can write PX without converting to REM, and browsers also support PX units